### PR TITLE
feat(ai): T052 pipeline v1 (section-aware chunks, guardrails, versioned outputs)

### DIFF
--- a/migrations/ai/0001_init.sql
+++ b/migrations/ai/0001_init.sql
@@ -1,0 +1,16 @@
+-- AI service versioning schema (optional; not yet wired)
+-- This migration is a placeholder for future DB-backed versioning if desired.
+
+CREATE TABLE IF NOT EXISTS ai_versions (
+  id uuid PRIMARY KEY,
+  doc_id text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  deprecated boolean NOT NULL DEFAULT false,
+  notes_path text NOT NULL,
+  flashcards_path text NOT NULL,
+  model text,
+  generation text
+);
+
+CREATE INDEX IF NOT EXISTS ai_versions_doc_id_idx ON ai_versions(doc_id);
+


### PR DESCRIPTION
Implements Phase 5 task T052 (AI pipeline v1):\n\n- Section-aware chunking for embeddings (split by markdown headings; sub-split long sections by paragraphs).\n- Guardrailed prompts: notes include inline [§ Section] citations; flashcards include optional hint and source fields; avoid direct exam answers.\n- Versioned outputs with manifest: new versionId per /ai/start; latest resolved by /ai/result and blob endpoints; legacy fallback supported.\n- New GET /ai/versions/:doc_id for introspection.\n- Placeholder migrations/ai/0001_init.sql for future DB-backed versioning (not used yet).\n\nTesting steps:\n1) Ingest a test document and run /api/ai/embed { doc_id } – verify embeddings JSON uses section IDs.\n2) Run /api/ai/start with doc_id – verify notes include [§ Section] citations (with real generation) and flashcards JSON has source and hint where possible.\n3) Fetch /api/ai/blob/:doc_id/notes and /flashcards – confirm the latest version is served and JSON is valid.\n4) Check /api/ai/versions/:doc_id – version history includes the new version.\n\nNotes:\n- Backward compatible: existing non-versioned artifacts still load.\n- No DB changes required to use versioning; files + manifest are sufficient.