### PR TITLE
feat(api+web): useAPI manual run + Search refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,8 @@ Thumbs.db
 # Local development
 .env.development.local
 
+# Ignore reference frontend from Lovable (kept outside workspace)
+lovable-frontend/
+
 # K8s local secrets (never commit real secrets)
 deploy/secrets.local.yaml


### PR DESCRIPTION
This PR adds manual-capable useAPI that returns data, error, and run(), and refactors the Search page to use manual search via TanStack Query.\n\nChanges:\n- talvra-api: useAPI supports { manual: true } and exposes run() to re-execute queries on demand while preserving the original return shape.\n- web Search: switched to useAPI manual mode; the Search button calls run(); loading and errors sourced from react-query state.\n- repo: ignore lovable-frontend folder to avoid embedding its nested git repo; keep it as a reference for porting UI.\n\nNotes:\n- Keeps TanStack Query as the stack via AppProvider QueryClient.\n- This sets up the next step where we’ll port Tabs, Chip, and Toast primitives from lovable-frontend to @ui and refactor Areas to use them.