### PR TITLE
feat(settings): Port lovable-style Settings UI using @ui primitives

### DIFF
--- a/frontend/packages/talvra-ui/src/Label.tsx
+++ b/frontend/packages/talvra-ui/src/Label.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import type { LabelHTMLAttributes, ReactNode } from 'react';
+
+export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+  children: ReactNode;
+  helperText?: ReactNode;
+}
+
+export const Label = styled.label<LabelProps>`
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  color: ${({ theme }) => theme.colors.gray[800]};
+  font-size: ${({ theme }) => theme.typography.fontSize.sm};
+
+  & > span.label-text {
+    font-weight: ${({ theme }) => theme.typography.fontWeight.medium};
+  }
+
+  & > small.helper-text {
+    color: ${({ theme }) => theme.colors.gray[500]};
+    font-size: ${({ theme }) => theme.typography.fontSize.xs};
+  }
+`;
+
+export default Label;

--- a/frontend/packages/talvra-ui/src/SectionHeader.tsx
+++ b/frontend/packages/talvra-ui/src/SectionHeader.tsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import type { ReactNode } from 'react';
+
+export interface SectionHeaderProps {
+  title: string;
+  subtitle?: string;
+  right?: ReactNode;
+}
+
+export function SectionHeader({ title, subtitle, right }: SectionHeaderProps) {
+  return (
+    <HeaderRoot>
+      <div className="left">
+        <h1 className="title">{title}</h1>
+        {subtitle && <p className="subtitle">{subtitle}</p>}
+      </div>
+      {right && <div className="right">{right}</div>}
+    </HeaderRoot>
+  );
+}
+
+const HeaderRoot = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  background: linear-gradient(90deg, ${({ theme }) => theme.colors.primary[50]} 0%, ${({ theme }) => theme.colors.white} 100%);
+  border: 1px solid ${({ theme }) => theme.colors.gray[200]};
+
+  .title {
+    margin: 0;
+    font-size: ${({ theme }) => theme.typography.fontSize['3xl']};
+    font-weight: ${({ theme }) => theme.typography.fontWeight.semibold};
+    color: ${({ theme }) => theme.colors.gray[900]};
+  }
+
+  .subtitle {
+    margin: 0.25rem 0 0 0;
+    color: ${({ theme }) => theme.colors.gray[600]};
+  }
+`;
+
+export default SectionHeader;

--- a/frontend/packages/talvra-ui/src/Select.tsx
+++ b/frontend/packages/talvra-ui/src/Select.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import type { SelectHTMLAttributes } from 'react';
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  fullWidth?: boolean;
+}
+
+export const Select = styled.select<SelectProps>`
+  display: block;
+  width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
+  padding: 0.5rem 0.75rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray[300]};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  background: ${({ theme }) => theme.colors.white};
+  color: ${({ theme }) => theme.colors.gray[800]};
+  box-shadow: ${({ theme }) => theme.shadows.inner};
+  transition: ${({ theme }) => theme.transitions.colors};
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.primary[600]};
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+  }
+
+  &:disabled {
+    background: ${({ theme }) => theme.colors.gray[100]};
+    cursor: not-allowed;
+    opacity: 0.8;
+  }
+`;
+
+export default Select;

--- a/frontend/packages/talvra-ui/src/Switch.tsx
+++ b/frontend/packages/talvra-ui/src/Switch.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+import type { InputHTMLAttributes } from 'react';
+
+export interface SwitchProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {}
+
+export function Switch(props: SwitchProps) {
+  return (
+    <SwitchRoot data-checked={props.checked ? 'true' : 'false'}>
+      <SwitchInput type="checkbox" {...props} />
+      <SwitchThumb />
+    </SwitchRoot>
+  );
+}
+
+const SwitchRoot = styled.label`
+  position: relative;
+  display: inline-flex;
+  width: 42px;
+  height: 24px;
+  border-radius: 9999px;
+  background: ${({ theme }) => theme.colors.gray[300]};
+  transition: ${({ theme }) => theme.transitions.all};
+  cursor: pointer;
+
+  &[data-checked='true'] {
+    background: ${({ theme }) => theme.colors.primary[600]};
+  }
+`;
+
+const SwitchInput = styled.input`
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  margin: 0;
+`;
+
+const SwitchThumb = styled.span`
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 9999px;
+  background: ${({ theme }) => theme.colors.white};
+  box-shadow: ${({ theme }) => theme.shadows.base};
+  transition: ${({ theme }) => theme.transitions.transform};
+
+  ${SwitchRoot}[data-checked='true'] & {
+    transform: translateX(18px);
+  }
+`;

--- a/frontend/packages/talvra-ui/src/Textarea.tsx
+++ b/frontend/packages/talvra-ui/src/Textarea.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import type { TextareaHTMLAttributes } from 'react';
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  fullWidth?: boolean;
+}
+
+export const Textarea = styled.textarea<TextareaProps>`
+  display: block;
+  width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
+  padding: 0.5rem 0.75rem;
+  border: 1px solid ${({ theme }) => theme.colors.gray[300]};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  background: ${({ theme }) => theme.colors.white};
+  color: ${({ theme }) => theme.colors.gray[800]};
+  box-shadow: ${({ theme }) => theme.shadows.inner};
+  font-family: ${({ theme }) => theme.typography.fontFamily.mono.join(', ')};
+  transition: ${({ theme }) => theme.transitions.colors};
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.primary[600]};
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+  }
+
+  &:disabled {
+    background: ${({ theme }) => theme.colors.gray[100]};
+    cursor: not-allowed;
+    opacity: 0.8;
+  }
+`;
+
+export default Textarea;

--- a/frontend/packages/talvra-ui/src/index.ts
+++ b/frontend/packages/talvra-ui/src/index.ts
@@ -15,6 +15,11 @@ export { GlassPanel, type GlassPanelProps } from './GlassPanel';
 export { Tabs, TabList, Tab, TabPanels, TabPanel, type TabsProps, type TabProps, type TabPanelProps } from './Tabs';
 export { Chip, type ChipProps } from './Chip';
 export { Toaster, useToast, type ToasterProps, type ToastOptions, type ToastVariant } from './Toast';
+export { Label, type LabelProps } from './Label';
+export { Select, type SelectProps } from './Select';
+export { Textarea, type TextareaProps } from './Textarea';
+export { Switch, type SwitchProps } from './Switch';
+export { SectionHeader, type SectionHeaderProps } from './SectionHeader';
 
 // Export theme
 export { theme, type Theme } from './theme';

--- a/frontend/web/src/Areas/Settings/index.tsx
+++ b/frontend/web/src/Areas/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { TalvraSurface, TalvraStack, TalvraText, TalvraLink, TalvraCard, TalvraButton, Tabs, TabList, Tab, TabPanels, TabPanel, Chip, Toaster } from '@ui';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraLink, TalvraCard, TalvraButton, Tabs, TabList, Tab, TabPanels, TabPanel, Chip, Toaster, Label, Input, Select, Textarea, SectionHeader } from '@ui';
 import { FRONT_ROUTES, buildPath } from '@/app/routes';
 import { CanvasTokenSettings } from '@/components/CanvasTokenSettings';
 import { useEffect, useState } from 'react';
@@ -172,7 +172,7 @@ export default function SettingsArea() {
     <TalvraSurface>
       <Toaster>
         <TalvraStack>
-          <TalvraText as="h1">Settings</TalvraText>
+<SectionHeader title="Settings" subtitle="Manage Canvas connection, email reminders, templates, and sync." />
 
           <Tabs defaultValue="canvas">
             <TalvraCard>
@@ -191,15 +191,15 @@ export default function SettingsArea() {
 
                 <TabPanel value="reminders">
                   <TalvraStack>
-                    <label>
-                      <TalvraText as="span">Test email (optional)</TalvraText>
-                      <input
+<Label>
+                      <span className="label-text">Test email (optional)</span>
+                      <Input
                         value={testEmail}
                         onChange={(e) => setTestEmail(e.target.value)}
                         placeholder="you@example.com (leave blank to use server default)"
-                        style={{ padding: 8, borderRadius: 6, border: '1px solid #cbd5e1', width: '100%' }}
+                        fullWidth
                       />
-                    </label>
+                    </Label>
                     <TalvraButton onClick={sendTestReminder}>Send test reminder</TalvraButton>
                     {testMsg && <TalvraText>{testMsg}</TalvraText>}
                   </TalvraStack>
@@ -207,52 +207,52 @@ export default function SettingsArea() {
 
                 <TabPanel value="templates">
                   <TalvraStack>
-                    <label>
-                      <TalvraText as="span">Template</TalvraText>
-                      <select
+<Label>
+                      <span className="label-text">Template</span>
+                      <Select
                         value={selectedTemplate}
                         onChange={(e) => setSelectedTemplate(e.target.value)}
-                        style={{ padding: 8, borderRadius: 6, border: '1px solid #cbd5e1', width: '100%' }}
+                        fullWidth
                       >
                         <option value="">Select a template</option>
                         {templates.map((t) => (
                           <option key={t.name} value={t.name}>{t.name}</option>
                         ))}
-                      </select>
-                    </label>
+                      </Select>
+                    </Label>
                     {selectedTemplate && (
                       <TalvraText style={{ color: '#6b7280' }}>
                         {templates.find((t) => t.name === selectedTemplate)?.description}
                         {' '}Fields: {(templates.find((t) => t.name === selectedTemplate)?.fields || []).join(', ')}
                       </TalvraText>
                     )}
-                    <label>
-                      <TalvraText as="span">To (optional)</TalvraText>
-                      <input
+<Label>
+                      <span className="label-text">To (optional)</span>
+                      <Input
                         value={templateTo}
                         onChange={(e) => setTemplateTo(e.target.value)}
                         placeholder="student@example.com (uses server default if blank)"
-                        style={{ padding: 8, borderRadius: 6, border: '1px solid #cbd5e1', width: '100%' }}
+                        fullWidth
                       />
-                    </label>
-                    <label>
-                      <TalvraText as="span">Subject (optional override)</TalvraText>
-                      <input
+                    </Label>
+<Label>
+                      <span className="label-text">Subject (optional override)</span>
+                      <Input
                         value={templateSubject}
                         onChange={(e) => setTemplateSubject(e.target.value)}
                         placeholder="Leave blank to use template default"
-                        style={{ padding: 8, borderRadius: 6, border: '1px solid #cbd5e1', width: '100%' }}
+                        fullWidth
                       />
-                    </label>
-                    <label>
-                      <TalvraText as="span">Vars (JSON)</TalvraText>
-                      <textarea
+                    </Label>
+<Label>
+                      <span className="label-text">Vars (JSON)</span>
+                      <Textarea
                         value={varsJson}
                         onChange={(e) => setVarsJson(e.target.value)}
                         rows={8}
-                        style={{ padding: 8, borderRadius: 6, border: '1px solid #cbd5e1', width: '100%', fontFamily: 'monospace' }}
+                        fullWidth
                       />
-                    </label>
+                    </Label>
                     <TalvraButton disabled={templateBusy || !selectedTemplate} onClick={sendTemplated}>
                       {templateBusy ? 'Sending…' : 'Send templated email'}
                     </TalvraButton>

--- a/frontend/web/src/components/CanvasTokenSettings.tsx
+++ b/frontend/web/src/components/CanvasTokenSettings.tsx
@@ -1,4 +1,4 @@
-import { TalvraStack, TalvraText, TalvraButton, Input, useToast } from '@ui';
+import { TalvraStack, TalvraText, TalvraButton, Input, useToast, Label } from '@ui';
 import { useAPI } from '@api';
 import { useState } from 'react';
 
@@ -94,7 +94,7 @@ export function CanvasTokenSettings() {
 
   return (
     <TalvraStack>
-      <TalvraText as="h4" style={{ marginTop: 16 }}>Canvas connection</TalvraText>
+<TalvraText as="h4">Canvas connection</TalvraText>
       {!isAuthed ? (
         <TalvraStack>
           <TalvraText>You are not logged in.</TalvraText>
@@ -105,20 +105,26 @@ export function CanvasTokenSettings() {
           <TalvraText>
             Provide your Canvas personal access token. Your institution base URL is fixed. We encrypt your token and never display it again.
           </TalvraText>
-          <Input
-            type="url"
-            placeholder="Canvas base URL (optional, e.g., https://morganstate.instructure.com)"
-            value={canvasBaseUrl}
-            onChange={(e) => setCanvasBaseUrl(e.target.value)}
-            fullWidth
-          />
-          <Input
-            type="password"
-            placeholder="Enter Canvas access token"
-            value={canvasToken}
-            onChange={(e) => setCanvasToken(e.target.value)}
-            fullWidth
-          />
+<Label>
+<span className="label-text">Canvas base URL (optional)</span>
+            <Input
+type="url"
+placeholder="e.g., https://morganstate.instructure.com"
+              value={canvasBaseUrl}
+              onChange={(e) => setCanvasBaseUrl(e.target.value)}
+              fullWidth
+            />
+          </Label>
+<Label>
+<span className="label-text">Canvas access token</span>
+            <Input
+type="password"
+placeholder="Enter Canvas access token"
+              value={canvasToken}
+              onChange={(e) => setCanvasToken(e.target.value)}
+              fullWidth
+            />
+          </Label>
           <TalvraStack>
             <TalvraButton disabled={busy || canvasToken.trim() === ''} onClick={saveCanvasToken}>
               Save token


### PR DESCRIPTION
This PR ports the Settings page styling to match the lovable frontend while adhering to our UI package patterns.

What’s included:
- New @ui primitives: Label, Select, Textarea, Switch, SectionHeader
- Refactored Settings page to use these primitives (no inline styles)
- CanvasTokenSettings now uses labeled fields for consistency
- Added gradient SectionHeader on the page

Notes:
- All components use styled-components with our theme tokens
- Build passes (vite)

After merge, the Settings page should closely match the lovable look while staying consistent with our component guidelines.