### PR TITLE
feat(ui): Divider + Settings polish (PageContainer, themed text)

### DIFF
--- a/frontend/packages/talvra-ui/src/Divider.tsx
+++ b/frontend/packages/talvra-ui/src/Divider.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export interface DividerProps {
+  marginY?: 'sm' | 'md' | 'lg';
+}
+
+const marginMap = {
+  sm: '0.5rem',
+  md: '1rem',
+  lg: '1.5rem',
+} as const;
+
+export const Divider = styled.hr<DividerProps>`
+  border: none;
+  border-top: 1px solid ${({ theme }) => theme.colors.gray[200]};
+  margin: ${({ marginY = 'md' }) => `${marginMap[marginY]} 0`};
+`;
+
+export default Divider;

--- a/frontend/packages/talvra-ui/src/index.ts
+++ b/frontend/packages/talvra-ui/src/index.ts
@@ -22,6 +22,7 @@ export { Switch, type SwitchProps } from './Switch';
 export { SectionHeader, type SectionHeaderProps } from './SectionHeader';
 export { Grid, type GridProps } from './Grid';
 export { PageContainer, type PageContainerProps } from './PageContainer';
+export { Divider, type DividerProps } from './Divider';
 export { Text, type TextProps } from './Text';
 
 // Export theme

--- a/frontend/web/src/Areas/Settings/index.tsx
+++ b/frontend/web/src/Areas/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { TalvraSurface, TalvraStack, TalvraText, TalvraLink, TalvraCard, TalvraButton, Tabs, TabList, Tab, TabPanels, TabPanel, Chip, Toaster, Label, Input, Select, Textarea, SectionHeader } from '@ui';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraLink, TalvraCard, TalvraButton, Tabs, TabList, Tab, TabPanels, TabPanel, Chip, Toaster, Label, Input, Select, Textarea, SectionHeader, PageContainer, Text as UiText, Divider } from '@ui';
 import { FRONT_ROUTES, buildPath } from '@/app/routes';
 import { CanvasTokenSettings } from '@/components/CanvasTokenSettings';
 import { useEffect, useState } from 'react';
@@ -171,8 +171,10 @@ export default function SettingsArea() {
   return (
     <TalvraSurface>
       <Toaster>
+        <PageContainer>
         <TalvraStack>
 <SectionHeader title="Settings" subtitle="Manage Canvas connection, email reminders, templates, and sync." />
+          <Divider />
 
           <Tabs defaultValue="canvas">
             <TalvraCard>
@@ -221,10 +223,10 @@ export default function SettingsArea() {
                       </Select>
                     </Label>
                     {selectedTemplate && (
-                      <TalvraText style={{ color: '#6b7280' }}>
+                      <UiText color="gray-500">
                         {templates.find((t) => t.name === selectedTemplate)?.description}
                         {' '}Fields: {(templates.find((t) => t.name === selectedTemplate)?.fields || []).join(', ')}
-                      </TalvraText>
+                      </UiText>
                     )}
 <Label>
                       <span className="label-text">To (optional)</span>
@@ -277,9 +279,9 @@ export default function SettingsArea() {
                             </Chip>
                             {job.status === 'failed' && job.error_message ? ` — ${job.error_message}` : ''}
                           </TalvraText>
-                          <TalvraText style={{ color: '#64748b' }}>
+                          <UiText color="gray-500">
                             processed {job.processed} • skipped {job.skipped} • errors {job.errors}
-                          </TalvraText>
+                          </UiText>
                         </TalvraStack>
                       </TalvraCard>
                     )}
@@ -304,6 +306,7 @@ export default function SettingsArea() {
             </TalvraStack>
           </TalvraStack>
         </TalvraStack>
+        </PageContainer>
       </Toaster>
     </TalvraSurface>
   );


### PR DESCRIPTION
This PR adds a Divider primitive and polishes the Settings page to align with the lovable look while following our UI patterns.

- Add Divider to @ui and export it
- Wrap Settings in PageContainer; add a Divider under the header
- Replace remaining inline color styles with themed Text (gray-500) in Settings
- Build passes locally (vite)

Next (optional):
- Introduce PageSection/Divider usage in other pages where needed
- Adopt ghost buttons for low-emphasis inline actions across the app
