### PR TITLE
feat(ui): PageSection + ghost buttons; consistent section layout

### DIFF
--- a/frontend/packages/talvra-ui/src/PageSection.tsx
+++ b/frontend/packages/talvra-ui/src/PageSection.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+export interface PageSectionProps {
+  gap?: 'sm' | 'md' | 'lg';
+}
+
+const gapMap = {
+  sm: '0.75rem',
+  md: '1rem',
+  lg: '1.5rem',
+} as const;
+
+export const PageSection = styled.section<PageSectionProps>`
+  display: block;
+  margin: 1.25rem 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ gap = 'md' }) => gapMap[gap]};
+`;
+
+export default PageSection;

--- a/frontend/packages/talvra-ui/src/index.ts
+++ b/frontend/packages/talvra-ui/src/index.ts
@@ -22,6 +22,7 @@ export { Switch, type SwitchProps } from './Switch';
 export { SectionHeader, type SectionHeaderProps } from './SectionHeader';
 export { Grid, type GridProps } from './Grid';
 export { PageContainer, type PageContainerProps } from './PageContainer';
+export { PageSection, type PageSectionProps } from './PageSection';
 export { Divider, type DividerProps } from './Divider';
 export { Text, type TextProps } from './Text';
 

--- a/frontend/web/src/Areas/Admin/index.tsx
+++ b/frontend/web/src/Areas/Admin/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { FRONT_ROUTES, buildPath } from '@/app/routes';
-import { TalvraStack, TalvraText, TalvraLink, TalvraButton, GlassPanel, SectionHeader, Grid, Text as UiText } from '@ui';
+import { TalvraStack, TalvraText, TalvraLink, TalvraButton, GlassPanel, SectionHeader, Grid, Text as UiText, PageContainer, PageSection } from '@ui';
 import { AuthPanel } from '@/components/AuthPanel';
 
 const API_BASE: string = (import.meta as any).env?.VITE_API_BASE ?? 'http://localhost:3001';
@@ -44,6 +44,7 @@ export default function AdminArea() {
   }
 
   return (
+    <PageContainer>
     <TalvraStack>
 <GlassPanel>
         <TalvraStack>
@@ -58,6 +59,7 @@ export default function AdminArea() {
         </TalvraStack>
       </GlassPanel>
 
+      <PageSection>
       <GlassPanel>
         <TalvraStack>
 <TalvraText as="h2">Recent documents</TalvraText>
@@ -76,8 +78,8 @@ export default function AdminArea() {
                     {d.mime_type ?? 'unknown'} • {new Date(d.created_at).toLocaleString()}
                   </UiText>
                   <TalvraStack style={{ marginTop: 8, flexDirection: 'row', gap: 8 }}>
-                    <TalvraLink href={`/documents/${encodeURIComponent(d.doc_id)}`}>Open</TalvraLink>
-                    <TalvraLink href={`/documents/${encodeURIComponent(d.doc_id)}/ai`}>AI</TalvraLink>
+                    <TalvraButton as="a" href={`/documents/${encodeURIComponent(d.doc_id)}`} variant="ghost">Open</TalvraButton>
+                    <TalvraButton as="a" href={`/documents/${encodeURIComponent(d.doc_id)}/ai`} variant="ghost">AI</TalvraButton>
                   </TalvraStack>
                 </GlassPanel>
               ))}
@@ -85,13 +87,17 @@ export default function AdminArea() {
           )}
         </TalvraStack>
       </GlassPanel>
+      </PageSection>
 
+      <PageSection>
       <GlassPanel>
         <TalvraStack>
           <TalvraText as="h2">Account</TalvraText>
           <AuthPanel />
         </TalvraStack>
       </GlassPanel>
+      </PageSection>
     </TalvraStack>
+    </PageContainer>
   );
 }

--- a/frontend/web/src/Areas/Courses/Detail.tsx
+++ b/frontend/web/src/Areas/Courses/Detail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraLink, TalvraButton, SectionHeader, Grid, PageContainer, Text as UiText } from '@ui';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraButton, SectionHeader, Grid, PageContainer, PageSection, Text as UiText } from '@ui';
 import { FRONT_ROUTES, buildPath } from '@/app/routes';
 import { getCourseDisplayName, setCourseDisplayName } from '@/utils/courseNames';
 
@@ -177,6 +177,7 @@ useEffect(() => {
       <TalvraStack>
 <SectionHeader title={header} right={<TalvraButton onClick={rename} variant="secondary">Rename</TalvraButton>} />
 
+<PageSection>
 <TalvraStack>
           <TalvraText as="h2">Documents</TalvraText>
           <TalvraStack>
@@ -227,7 +228,9 @@ useEffect(() => {
             </TalvraStack>
           </TalvraCard>
         </TalvraStack>
+        </PageSection>
 
+        <PageSection>
         <TalvraStack>
           <TalvraText as="h2">Assignments</TalvraText>
           {errorAssign && <TalvraText>Error loading assignments: {errorAssign}</TalvraText>}
@@ -257,7 +260,9 @@ useEffect(() => {
             </TalvraStack>
           </TalvraCard>
         </TalvraStack>
+        </PageSection>
 
+        <PageSection>
         <TalvraStack>
           <TalvraText as="h2">Navigation</TalvraText>
           <TalvraStack>
@@ -269,6 +274,7 @@ useEffect(() => {
             </TalvraLink>
           </TalvraStack>
         </TalvraStack>
+        </PageSection>
       </TalvraStack>
       </PageContainer>
     </TalvraSurface>

--- a/frontend/web/src/Areas/Documents/AI.tsx
+++ b/frontend/web/src/Areas/Documents/AI.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraButton, TalvraLink, SectionHeader, CodeBlock, PageContainer, Text as UiText } from '@ui';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraButton, SectionHeader, CodeBlock, PageContainer, PageSection, Text as UiText } from '@ui';
 import { useParams } from 'react-router-dom';
 
 const API_BASE: string = (import.meta as any).env?.VITE_API_BASE ?? 'http://localhost:3001';
@@ -82,6 +82,7 @@ export default function DocumentAI() {
           {busy ? 'Starting…' : 'Start AI'}
         </TalvraButton>
 
+        <PageSection>
         <TalvraCard>
           <TalvraStack>
             <TalvraText as="h3">Notes</TalvraText>
@@ -91,6 +92,8 @@ export default function DocumentAI() {
           </TalvraStack>
         </TalvraCard>
 
+        </PageSection>
+        <PageSection>
         <TalvraCard>
           <TalvraStack>
             <TalvraText as="h3">Flashcards</TalvraText>
@@ -156,7 +159,10 @@ export default function DocumentAI() {
           </TalvraStack>
         </TalvraCard>
 
-        <TalvraLink href={`/documents/${documentId}`}>Back to Document</TalvraLink>
+        </PageSection>
+        <PageSection>
+        <TalvraButton as="a" href={`/documents/${documentId}`} variant="ghost">Back to Document</TalvraButton>
+        </PageSection>
       </TalvraStack>
       </PageContainer>
     </TalvraSurface>

--- a/frontend/web/src/Areas/Documents/Detail.tsx
+++ b/frontend/web/src/Areas/Documents/Detail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraLink, TalvraButton, Input, CodeBlock, SectionHeader, PageContainer, Text as UiText } from '@ui';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraButton, Input, CodeBlock, SectionHeader, PageContainer, PageSection, Text as UiText } from '@ui';
 import { useParams } from 'react-router-dom';
 
 const API_BASE: string = (import.meta as any).env?.VITE_API_BASE ?? 'http://localhost:3001';
@@ -121,6 +121,7 @@ export default function DocumentDetailArea() {
 <SectionHeader title={`Document: ${documentId ?? ''}`} />
         {error && <TalvraText>Error: {error}</TalvraText>}
 
+        <PageSection>
         <TalvraCard>
           <TalvraStack>
             <TalvraText as="h3">Embeddings</TalvraText>
@@ -133,6 +134,8 @@ export default function DocumentDetailArea() {
           </TalvraStack>
         </TalvraCard>
 
+        </PageSection>
+        <PageSection>
         <TalvraCard>
           <TalvraStack>
             <TalvraText as="h3">Semantic search (within this document)</TalvraText>
@@ -177,6 +180,8 @@ export default function DocumentDetailArea() {
           </TalvraStack>
         </TalvraCard>
 
+        </PageSection>
+        <PageSection>
         <TalvraCard>
           <TalvraStack>
             <TalvraText as="h3">Structure</TalvraText>
@@ -195,11 +200,14 @@ export default function DocumentDetailArea() {
           </TalvraStack>
         </TalvraCard>
 
+        </PageSection>
+        <PageSection>
         <TalvraStack>
-          <TalvraLink href="/documents">Back to Documents</TalvraLink>
-          <TalvraLink href={`/documents/${documentId}/ai`}>View AI outputs</TalvraLink>
-          <TalvraLink href={`/documents/${documentId}/video`}>View Video</TalvraLink>
+          <TalvraButton as="a" href="/documents" variant="ghost">Back to Documents</TalvraButton>
+          <TalvraButton as="a" href={`/documents/${documentId}/ai`} variant="ghost">View AI outputs</TalvraButton>
+          <TalvraButton as="a" href={`/documents/${documentId}/video`} variant="ghost">View Video</TalvraButton>
         </TalvraStack>
+        </PageSection>
       </TalvraStack>
       </PageContainer>
     </TalvraSurface>

--- a/frontend/web/src/Areas/Documents/index.tsx
+++ b/frontend/web/src/Areas/Documents/index.tsx
@@ -1,4 +1,4 @@
-import { TalvraSurface, TalvraStack, TalvraText, TalvraLink, TalvraCard, SectionHeader, Grid, PageContainer, Text as UiText } from '@ui';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraButton, TalvraCard, SectionHeader, Grid, PageContainer, PageSection, Text as UiText } from '@ui';
 import { FRONT_ROUTES, buildPath } from '@/app/routes';
 import { useEffect, useState } from 'react';
 
@@ -46,6 +46,7 @@ export default function DocumentsArea() {
 <SectionHeader title="Documents" subtitle="Recently ingested content and outputs." />
         {error && <TalvraText>Error loading documents: {error}</TalvraText>}
 
+        <PageSection>
         <TalvraCard>
           <TalvraStack>
             <TalvraText as="h3">Recent documents</TalvraText>
@@ -60,9 +61,9 @@ export default function DocumentsArea() {
                     <TalvraStack>
                       <TalvraText as="h4">{d.title ?? d.doc_id}</TalvraText>
                       <TalvraStack>
-                        <TalvraLink href={`/documents/${encodeURIComponent(d.doc_id)}`}>Open</TalvraLink>
-                        <TalvraLink href={`/documents/${encodeURIComponent(d.doc_id)}/ai`}>AI</TalvraLink>
-                        <TalvraLink href={`/documents/${encodeURIComponent(d.doc_id)}/video`}>Video</TalvraLink>
+                        <TalvraButton as="a" href={`/documents/${encodeURIComponent(d.doc_id)}`} variant="ghost">Open</TalvraButton>
+                        <TalvraButton as="a" href={`/documents/${encodeURIComponent(d.doc_id)}/ai`} variant="ghost">AI</TalvraButton>
+                        <TalvraButton as="a" href={`/documents/${encodeURIComponent(d.doc_id)}/video`} variant="ghost">Video</TalvraButton>
                       </TalvraStack>
                       <UiText color="gray-500">
                         {d.mime_type ?? 'unknown'} • {d.size_bytes ? `${d.size_bytes} bytes` : 'size unknown'} • {new Date(d.created_at).toLocaleString()}
@@ -74,7 +75,9 @@ export default function DocumentsArea() {
             )}
           </TalvraStack>
         </TalvraCard>
+        </PageSection>
 
+        <PageSection>
         <TalvraCard>
           <TalvraStack>
             <TalvraText as="h3">How to process a file</TalvraText>
@@ -89,7 +92,9 @@ export default function DocumentsArea() {
             </TalvraText>
           </TalvraStack>
         </TalvraCard>
+        </PageSection>
 
+        <PageSection>
         <TalvraStack>
           <TalvraText as="h2">Navigation</TalvraText>
           <TalvraStack>
@@ -107,6 +112,7 @@ export default function DocumentsArea() {
             </TalvraLink>
           </TalvraStack>
         </TalvraStack>
+        </PageSection>
       </TalvraStack>
       </PageContainer>
     </TalvraSurface>

--- a/frontend/web/src/Areas/Search/index.tsx
+++ b/frontend/web/src/Areas/Search/index.tsx
@@ -1,4 +1,4 @@
-import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraLink, TalvraButton, Label, Input, Select, SectionHeader, CodeBlock, PageContainer, Text as UiText } from '@ui';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraButton, Label, Input, Select, SectionHeader, CodeBlock, PageContainer, PageSection, Text as UiText } from '@ui';
 import { useEffect, useMemo, useState } from 'react';
 import { getCourseDisplayName } from '@/utils/courseNames';
 import { useAPI } from '@api';
@@ -128,6 +128,7 @@ export default function SearchArea() {
       <TalvraStack>
 <SectionHeader title="Search" subtitle="Semantic search across your content." />
 
+        <PageSection>
         <TalvraCard>
           <TalvraStack>
 <Label>
@@ -199,7 +200,9 @@ export default function SearchArea() {
             )}
           </TalvraStack>
         </TalvraCard>
+        </PageSection>
 
+        <PageSection>
         <TalvraCard>
           <TalvraStack>
             <TalvraText as="h3">Results</TalvraText>
@@ -225,7 +228,7 @@ export default function SearchArea() {
 <CodeBlock>
                           {r.snippet}
                         </CodeBlock>
-                        <TalvraLink href={`/documents/${encodeURIComponent(r.doc_id)}`}>Open document</TalvraLink>
+                        <TalvraButton as="a" href={`/documents/${encodeURIComponent(r.doc_id)}`} variant="ghost">Open document</TalvraButton>
                       </TalvraStack>
                     </TalvraCard>
                   );
@@ -234,6 +237,7 @@ export default function SearchArea() {
             )}
           </TalvraStack>
         </TalvraCard>
+        </PageSection>
       </TalvraStack>
       </PageContainer>
     </TalvraSurface>


### PR DESCRIPTION
This PR continues the lovable UI sweep:

- Add PageSection to @ui and export it
- Wrap sections with PageSection across Admin, Documents, Document Detail, Search, Course Detail
- Convert inline actions to ghost TalvraButton (Open, AI, Video, Open document)
- Keep external links (e.g., Open in Canvas) as anchors
- Verified vite build

Follow-ups (optional):
- Apply ghost variant to any remaining inline actions
- Consider a CardHeader primitive for consistent h3/title spacing inside cards
